### PR TITLE
Quick fix for purescript-test-unit's deleted tag

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,6 +26,6 @@
     "purescript-refs": "^0.2.0"
   },
   "devDependencies": {
-    "purescript-test-unit": "^2.0.1"
+    "purescript-test-unit": "^3.0.0"
   }
 }


### PR DESCRIPTION
To my dismay, the tag of `purescript-test-unit` that was just released got DELETED (discussion [here](https://github.com/bodil/purescript-test-unit/commit/d91bb6d8c18f7a635aed2398fa376a3b08913631#commitcomment-13577804)), which of course causes failure across our packages.

This commit fixes the build. Once merged, this should be released in `purescript-aff-reattempt` as a _patch version_ in order to silently fix all the packages that depend on it.
