### PR TITLE
Upgraded project to PureScript v0.9.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,10 +22,11 @@
     "bower.json"
   ],
   "dependencies": {
-    "purescript-aff": "^0.16.0",
-    "purescript-refs": "^0.2.0"
+    "purescript-aff": "^1.0.0",
+    "purescript-refs": "^1.0.0"
   },
   "devDependencies": {
-    "purescript-test-unit": "^3.0.0"
+    "purescript-test-unit": "^7.0.0",
+    "purescript-parallel": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,11 +2,14 @@
   "private": true,
   "scripts": {
     "clean": "rimraf output && rimraf .pulp-cache",
-    "build": "pulp build"
+    "build": "pulp build",
+    "test": "pulp test",
+    "bower": "bower"
   },
   "devDependencies": {
-    "pulp": "^8.1.0",
-    "purescript": "^0.7.6",
-    "rimraf": "^2.5.2"
+    "pulp": "^9.0.1",
+    "purescript": "^0.9.1",
+    "rimraf": "^2.5.2",
+    "bower": "^1.7.1"
   }
 }

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -4,18 +4,26 @@ import Prelude
 import Control.Apply ((*>))
 import Control.Alt ((<|>))
 import Control.Monad.Aff.AVar (makeVar', takeVar, putVar, AVar(), AVAR())
-import Control.Monad.Aff.Par (Par(..), runPar)
-import Control.Monad.Aff (attempt, later, later', launchAff, Aff())
-import Control.Monad.Eff.Class (liftEff)
-import Control.Monad.Error.Class (catchError)
+import Control.Monad.Aff (attempt, later, later', Aff)
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Ref (REF)
+import Control.Monad.Eff.Console (CONSOLE)
+import Control.Parallel.Class (parallel, runParallel)
 import Control.Plus (empty)
-import Data.Either (Either(..), either)
+import Data.Either as Either
 import Data.Functor (($>))
 import Data.Maybe (maybe, fromMaybe)
-import Data.Array (replicate, head, tail)
-import Test.Unit (runTest, test, assertFn)
+import Data.Array (head, tail)
+import Data.Unfoldable (replicate)
+import Test.Unit (test, suite)
+import Test.Unit.Assert (assert)
+import Test.Unit.Console (TESTOUTPUT)
+import Test.Unit.Main (runTest)
 
 import Control.Monad.Aff.Reattempt (reattempt)
+
+ignore :: forall m a. Monad m => m a -> m Unit
+ignore m = m >>= (\_ -> pure unit)
 
 failAffsForDurationAndNumberOfAttempts :: forall e. Int -> Int -> Array (Aff e Unit)
 failAffsForDurationAndNumberOfAttempts timeout attemptCount = seq
@@ -29,44 +37,34 @@ affDouble affsVar = do
   putVar affsVar (fromMaybe [] (tail affs))
   maybe (pure unit) id $ head affs
 
+main :: forall eff. Eff (console :: CONSOLE, testOutput :: TESTOUTPUT, ref :: REF, avar :: AVAR | eff) Unit
 main = runTest do
-  test "When the Aff never succeeds" do
+  test "When the Aff never succeeds the returned Aff should fail" do
+    result <- attempt $ reattempt 100 (later empty)
+    assert "The returned Aff did not fail" $ Either.isLeft result
 
-    assertFn "The returned Aff should fail" \done ->
-      launchAff $ do
-        result <- attempt $ reattempt 100 (later empty)
-        liftEff $ either (const $ done true) (const $ done false) result
+  test "When the timeout will elapse before any attempts to run the Aff are successful the returned Aff should fail" do
+    seq <- makeVar' $ failAffsForDurationAndNumberOfAttempts 1000 10
+    result <- attempt $ reattempt 100 (affDouble seq)
+    assert "The returned Aff did not fail" $ Either.isLeft result
 
-  test "When the timeout will elapse before any attempts to run the Aff are successful" do
+  test "When the Aff always succeeds the returned Aff must be successful" do
+    result <- attempt $ reattempt 10000 (later' 1000 $ pure unit)
+    assert "The returned Aff failed" $ Either.isRight result
 
-    assertFn "The returned Aff should fail" \done ->
-      launchAff $ do
-        seq <- makeVar' $ failAffsForDurationAndNumberOfAttempts 1000 10
-        result <- attempt $ reattempt 100 (affDouble seq)
-        liftEff $ either (const $ done true) (const $ done false) result
+  suite "When the Aff will succeed during an attempt started before the timeout will elapse" do
 
-  test "When the Aff always succeeds" do
+    test "The returned Aff should be successful" do
+      seq <- makeVar' $ failAffsForDurationAndNumberOfAttempts 100 10
+      result <- attempt $ reattempt 100000000 (affDouble seq)
+      assert "The returned Aff failed" $ Either.isRight result
 
-    assertFn "The returned Aff be successful" \done ->
-      launchAff $ do
-        result <- attempt $ reattempt 10000 (later' 1000 $ pure unit)
-        liftEff $ either (const $ done false) (const $ done true) result
-
-  test "When the Aff will succeed during an attempt started before the timeout will elapse" do
-
-    assertFn "The returned Aff should be successful" \done ->
-      launchAff $ do
-        seq <- makeVar' $ failAffsForDurationAndNumberOfAttempts 100 10
-        result <- attempt $ reattempt 100000000 (affDouble seq)
-        liftEff $ either (const $ done false) (const $ done true) result
-
-    assertFn "The returned Aff should not wait for the timeout to elapse in order to succeed" \done ->
-      launchAff $ do
-        seq <- makeVar' $ failAffsForDurationAndNumberOfAttempts 100 10
-        let parReattempt = Par (reattempt 100000000 (affDouble seq) $> true)
-        let parLater = Par (later' 1000 $ pure false)
-        result <- runPar $ parReattempt <|> parLater
-        liftEff $ done result
+    test "The returned Aff should not wait for the timeout to elapse in order to succeed" do
+      seq <- makeVar' $ failAffsForDurationAndNumberOfAttempts 100 10
+      let parReattempt = parallel (reattempt 100000000 (affDouble seq) $> true)
+      let parLater = parallel (later' 1000 $ pure false)
+      result <- runParallel $ parReattempt <|> parLater
+      assert "The returned Aff failed" result
 
   -- TODO: Test that process finishes when attempt is successful.
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -22,9 +22,6 @@ import Test.Unit.Main (runTest)
 
 import Control.Monad.Aff.Reattempt (reattempt)
 
-ignore :: forall m a. Monad m => m a -> m Unit
-ignore m = m >>= (\_ -> pure unit)
-
 failAffsForDurationAndNumberOfAttempts :: forall e. Int -> Int -> Array (Aff e Unit)
 failAffsForDurationAndNumberOfAttempts timeout attemptCount = seq
   where


### PR DESCRIPTION
We're looking to use purescript-webdriver in our project; but our project is using PureScript 0.9. This project is a dependency of purescript-webdriver, which I'm also looking at upgrading to PureScript 0.9 if I can. So I've first upgraded this project to PureScript 0.9 and upgraded its dependent libraries to the latest version which are compatible with 0.9.

The biggest change is in the unit tests which have been restructured to use the latest purescript-test-unit, which now has direct support for tests in `Aff`. Parallel types were also moved into purescript-parallel, so I switched the tests to use those.

I also added bower as a dev dependency, as I required it to install the dependent packages. I assume you guys must have it globally installed, but I try to avoid implicit global installation of packages where possible; hence me adding it as a dev dependency. Happy to revert that bit if you don't like it.
